### PR TITLE
Code improvements and fixes to banklibs, clashit, e_pid and getElectronInfo

### DIFF
--- a/banklib/BBand.cpp
+++ b/banklib/BBand.cpp
@@ -67,10 +67,10 @@ BBand::BBand(hipo::schema __schema) : hipo::bank(__schema){
 // ==============================================================
 BBand::~BBand(){}
 // ==============================================================
-int BBand::getBarKey(int index)
+int BBand::getBarKey(int row)
 {
-	int s = getSector   (index);
-	int l = getLayer    (index);
-	int c = getComponent(index);
+	int s = getSector   (row);
+	int l = getLayer    (row);
+	int c = getComponent(row);
 	return s*100+l*10+c;
 }

--- a/banklib/BCalorimeter.cpp
+++ b/banklib/BCalorimeter.cpp
@@ -3,6 +3,7 @@
 // ==============================================================
 BCalorimeter::BCalorimeter(hipo::schema __schema) : hipo::bank(__schema){
 
+	index_order    = __schema.getEntryOrder("index"    );
 	pindex_order   = __schema.getEntryOrder("pindex"   );
 	detector_order = __schema.getEntryOrder("detector" );
 	sector_order   = __schema.getEntryOrder("sector"   );
@@ -21,11 +22,35 @@ BCalorimeter::BCalorimeter(hipo::schema __schema) : hipo::bank(__schema){
 // ==============================================================
 BCalorimeter::~BCalorimeter(){}
 // ==============================================================
+int BCalorimeter::getElectronSector (int pindex)
+{
+	//Sector of PCAL hit layer 1
+	int nCal = getRows();
+	for(int i = 0 ; i < nCal ; i++){
+		if(BCalorimeter::getPindex(i)==pindex&&BCalorimeter::getLayer(i)==1 && BCalorimeter::getDetector(i)==7){
+			return BCalorimeter::getSector(i);
+		}
+	}
+	return -1;
+}
+// ==============================================================
+int BCalorimeter::getPcalRow (int pindex)
+{
+	//Find row of BANK with PCAL for Particle Index
+	int nCal = getRows();
+	for(int i = 0 ; i < nCal ; i++){
+		if(BCalorimeter::getPindex(i)==pindex&&BCalorimeter::getLayer(i)==1 && BCalorimeter::getDetector(i)==7){
+			return i;
+		}
+	}
+	return -1;
+}
+// ==============================================================
 float BCalorimeter::getPcalE (int pindex)
 {
 	int nCal = getRows();
 	for(int i = 0 ; i < nCal ; i++){
-		if(BCalorimeter::getIndex(i)==pindex&&BCalorimeter::getLayer(i)==1){
+		if(BCalorimeter::getPindex(i)==pindex&&BCalorimeter::getLayer(i)==1 && BCalorimeter::getDetector(i)==7){
 			return BCalorimeter::getEnergy(i);
 		}
 	}
@@ -35,23 +60,23 @@ float BCalorimeter::getPcalE (int pindex)
 float BCalorimeter::getECinE (int pindex)
 {
 	int nCal = getRows();
-        for(int i = 0 ; i < nCal ; i++){
-                if(BCalorimeter::getIndex(i)==pindex&&BCalorimeter::getLayer(i)==4){
-                        return BCalorimeter::getEnergy(i);
-                }
-        }
-        return 0;
+	for(int i = 0 ; i < nCal ; i++){
+		if(BCalorimeter::getPindex(i)==pindex&&BCalorimeter::getLayer(i)==4 && BCalorimeter::getDetector(i)==7){
+			return BCalorimeter::getEnergy(i);
+		}
+	}
+	return 0;
 }
 // ==============================================================
 float BCalorimeter::getECoutE(int pindex)
 {
 	int nCal = getRows();
-        for(int i = 0 ; i < nCal ; i++){
-                if(BCalorimeter::getIndex(i)==pindex&&BCalorimeter::getLayer(i)==7){
-                        return BCalorimeter::getEnergy(i);
-                }
-        }
-        return 0;
+	for(int i = 0 ; i < nCal ; i++){
+		if(BCalorimeter::getPindex(i)==pindex&&BCalorimeter::getLayer(i)==7 && BCalorimeter::getDetector(i)==7){
+			return BCalorimeter::getEnergy(i);
+		}
+	}
+	return 0;
 }
 // ==============================================================
 float BCalorimeter::getTotE  (int pindex)

--- a/banklib/BParticle.cpp
+++ b/banklib/BParticle.cpp
@@ -19,22 +19,22 @@ BParticle::BParticle(hipo::schema __schema) : hipo::bank(__schema){
 // ==============================================================
 BParticle::~BParticle(){}
 // ==============================================================
-TVector3 BParticle::getV3v(int index)
+TVector3 BParticle::getV3v(int row)
 {
 	TVector3 * V3v = new TVector3();
-        float vx = BParticle::getVx(index);
-        float vy = BParticle::getVy(index);
-        float vz = BParticle::getVz(index);
-        V3v -> SetXYZ(vx,vy,vz);
-        return * V3v;
+	float vx = BParticle::getVx(row);
+	float vy = BParticle::getVy(row);
+	float vz = BParticle::getVz(row);
+	V3v -> SetXYZ(vx,vy,vz);
+	return * V3v;
 }
 // ==============================================================
-TVector3 BParticle::getV3P(int index)
+TVector3 BParticle::getV3P(int row)
 {
 	TVector3 * V3P = new TVector3();
-	float px = BParticle::getPx(index);
-	float py = BParticle::getPy(index);
-	float pz = BParticle::getPz(index);
+	float px = BParticle::getPx(row);
+	float py = BParticle::getPy(row);
+	float pz = BParticle::getPz(row);
 	V3P -> SetXYZ(px,py,pz);
 	return * V3P;
 }

--- a/clashit/clashit.cpp
+++ b/clashit/clashit.cpp
@@ -1,4 +1,5 @@
 #include "clashit.h"
+#include <iostream>
 
 ClassImp(clashit);
 
@@ -6,7 +7,7 @@ clashit::clashit(){}	// Empty constructor
 clashit::~clashit(){}	// Empty destructor
 
 void clashit::Clear(){
-	Sector		= 0;
+	Sector		= -1;
 	PID		= 0;
 	Charge		= 0;
 	Status		= 0;
@@ -56,4 +57,23 @@ void clashit::Clear(){
 	DC_x3           = -999;
 	DC_y3           = -999;
 	DC_z3           = -999;
+}
+
+
+void clashit::Print(){
+
+	std::cout << "clashit Information REC: PID " << PID << " , Charge " << Charge << " , Status " << Status;
+	std::cout << ", Sector(Calo) " << Sector << " , Chi2 " << Chi2 << ", Time " << Time << " , Beta " << Beta << std::endl;
+	std::cout << "clashit Information CALO: Etot " << Etot << " , Epcal " << Epcal << ", Eecin " << Eecin;
+	std::cout << ", Eecout " << Eecout << ", EoverP " << EoP << " , U(PCal) " << U << " , V(ECal) " << V << " , W(ECal) " << W << std::endl;
+	std::cout << "clashit Information Vertex: Vtx " << Vtx << " , Vty " << Vty << ", Vtz " << Vtz;
+	std::cout << ", TimeScint(-starttime) " << TimeScint << " , Pathlength Scint " << PathScint << std::endl;
+	std::cout << "clashit Information DC: DC_chi2 " << DC_chi2 << " , DC_NDF " << DC_NDF << ", DC_sector " << DC_sector;
+	std::cout << ", DC_x1 " << DC_x1 << " , DC_y1 " << DC_y1 << " , DC_z1 " << DC_z1 << std::endl;
+	std::cout << "clashit Information DC: DC_x2 " << DC_x2 << " , DC_y2 " << DC_y2<< " , DC_z2 " << DC_z2;
+	std::cout << ", DC_x3 " << DC_x3 << " , DC_y3 " << DC_y3 << " , DC_z3 " << DC_z3 << std::endl;
+	std::cout << "clashit Information Kinematics: Momentum " << Momentum << " , Theta " << Theta << " ,Phi " << Phi;
+	std::cout << ", Q2 " << Q2 << " , Omega/nu " << Omega << " , Xb " << Xb << " , W2 " << W2 << std::endl;
+	std::cout << "clashit Information q-vector: Magitude(q) " << Q << " , ThetaQ " << ThetaQ << " ,PhiQ " << PhiQ << std::endl;
+
 }

--- a/include/BBand.h
+++ b/include/BBand.h
@@ -56,100 +56,100 @@ class BBand : public hipo::bank {
 		~BBand();
 
 		bool  isOldfile       () 					{ return oldfile;}
-		int   getId           (int index) { return getInt   (id_order           ,index);}
-		int   getSector       (int index) { return getInt   (sector_order       ,index);}
-		int   getLayer        (int index) { return getInt   (layer_order        ,index);}
-		int   getComponent    (int index) { return getInt   (component_order    ,index);}
-		float getMeantimeTdc  (int index) { return getFloat (meantimeTdc_order  ,index);}
-		float getMeantimeFadc (int index) { return getFloat (meantimeFadc_order ,index);}
-		float getDifftimeTdc  (int index) { return getFloat (difftimeTdc_order  ,index);}
-		float getDifftimeFadc (int index) { return getFloat (difftimeFadc_order ,index);}
-		float getX            (int index) { return getFloat (x_order            ,index);}
-		float getY            (int index) { return getFloat (y_order            ,index);}
-		float getZ            (int index) { return getFloat (z_order            ,index);}
-		float getUx           (int index) { return getFloat (ux_order           ,index);}
-		float getUy           (int index) { return getFloat (uy_order           ,index);}
-		float getUz           (int index) { return getFloat (uz_order           ,index);}
+		int   getId           (int row) { return getInt   (id_order           ,row);}
+		int   getSector       (int row) { return getInt   (sector_order       ,row);}
+		int   getLayer        (int row) { return getInt   (layer_order        ,row);}
+		int   getComponent    (int row) { return getInt   (component_order    ,row);}
+		float getMeantimeTdc  (int row) { return getFloat (meantimeTdc_order  ,row);}
+		float getMeantimeFadc (int row) { return getFloat (meantimeFadc_order ,row);}
+		float getDifftimeTdc  (int row) { return getFloat (difftimeTdc_order  ,row);}
+		float getDifftimeFadc (int row) { return getFloat (difftimeFadc_order ,row);}
+		float getX            (int row) { return getFloat (x_order            ,row);}
+		float getY            (int row) { return getFloat (y_order            ,row);}
+		float getZ            (int row) { return getFloat (z_order            ,row);}
+		float getUx           (int row) { return getFloat (ux_order           ,row);}
+		float getUy           (int row) { return getFloat (uy_order           ,row);}
+		float getUz           (int row) { return getFloat (uz_order           ,row);}
 		//next 6 functions are exclusively for old BAND::hits structure
-		float getAdcLcorr     (int index) {
+		float getAdcLcorr     (int row) {
 			if (oldfile == false) {
 				std::cout << "Warning from BBand class: Usage of getAdcLcorr with new file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (adcLcorr_order    ,index);
+			return getFloat (adcLcorr_order    ,row);
 		}
-		float getAdcRcorr     (int index) {
+		float getAdcRcorr     (int row) {
 			if (oldfile == false) {
 				std::cout << "Warning from BBand class: Usage of getAdcRcorr with new file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (adcRcorr_order     ,index);
+			return getFloat (adcRcorr_order     ,row);
 		}
-		float getTfadcLcorr   (int index) {
+		float getTfadcLcorr   (int row) {
 			if (oldfile == false) {
 				std::cout << "Warning from BBand class: Usage of getTfadcLcorr with new file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (tFadcLcorr_order   ,index);
+			return getFloat (tFadcLcorr_order   ,row);
 		}
-		float getTfadcRcorr   (int index) {
+		float getTfadcRcorr   (int row) {
 			if (oldfile == false) {
 				std::cout << "Warning from BBand class: Usage of getTfadcRcorr with new file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (tFadcRcorr_order   ,index);
+			return getFloat (tFadcRcorr_order   ,row);
 		}
-		float getTtdcLcorr    (int index) {
+		float getTtdcLcorr    (int row) {
 			if (oldfile == false) {
 				std::cout << "Warning from BBand class: Usage of getTtdcLcorr with new file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (tTdcLcorr_order    ,index);
+			return getFloat (tTdcLcorr_order    ,row);
 		}
-		float getTtdcRcorr    (int index) {
+		float getTtdcRcorr    (int row) {
 			if (oldfile == false) {
 				std::cout << "Warning from BBand class: Usage of getTtdcRcorr with new file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (tTdcRcorr_order    ,index);
+			return getFloat (tTdcRcorr_order    ,row);
 		}
 		//next functions are for BAND::hits new structure. some of them are mapped to the same class members than previous get-functions
-		float getEx           (int index) { return getFloat (ux_order           ,index);}
-		float getEy           (int index) { return getFloat (uy_order           ,index);}
-		float getEz           (int index) { return getFloat (uz_order           ,index);}
-		float getTime         (int index) { return getFloat (meantimeTdc_order  ,index);}
-		float getTimeFadc     (int index) { return getFloat (meantimeFadc_order ,index);}
+		float getEx           (int row) { return getFloat (ux_order           ,row);}
+		float getEy           (int row) { return getFloat (uy_order           ,row);}
+		float getEz           (int row) { return getFloat (uz_order           ,row);}
+		float getTime         (int row) { return getFloat (meantimeTdc_order  ,row);}
+		float getTimeFadc     (int row) { return getFloat (meantimeFadc_order ,row);}
 		//exclusively for new BAND::hits structure
-		float getEnergy       (int index) {
+		float getEnergy       (int row) {
 			if (oldfile == true) {
 				std::cout << "Warning from BBand class: Usage of getEnergy with old file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getFloat (energy_order       ,index);
+			return getFloat (energy_order       ,row);
 		}
-		int   getLpmtindex    (int index) {
+		int   getLpmtindex    (int row) {
 			if (oldfile == true) {
 				std::cout << "Warning from BBand class: Usage of getLpmtindex with old file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getInt   (indexLpmt_order    ,index);
+			return getInt   (indexLpmt_order    ,row);
 		}
-		int   getRpmtindex    (int index) {
+		int   getRpmtindex    (int row) {
 			if (oldfile == true) {
 				std::cout << "Warning from BBand class: Usage of getRpmtindex with old file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getInt   (indexRpmt_order    ,index);
+			return getInt   (indexRpmt_order    ,row);
 		}
-		int   getStatus       (int index) {
+		int   getStatus       (int row) {
 			if (oldfile == true) {
 				std::cout << "Warning from BBand class: Usage of getStatus with old file or constructor was used wrong. Return 0 " << std::endl;
 				return 0;
 			}
-			return getInt   (status_order       ,index);
+			return getInt   (status_order       ,row);
 		}
 
-		int   getBarKey(int index);
+		int   getBarKey(int row);
 };
 
 #endif

--- a/include/BCalorimeter.h
+++ b/include/BCalorimeter.h
@@ -15,6 +15,7 @@
 class BCalorimeter : public hipo::bank {
 
 	private:
+		int index_order    ;
 		int pindex_order   ;
 		int detector_order ;
 		int sector_order   ;
@@ -37,15 +38,19 @@ class BCalorimeter : public hipo::bank {
 
 		~BCalorimeter();
 
-		int   getIndex   (int index) { return getInt  (pindex_order    ,index);}
-		int   getDetector(int index) { return getInt  (detector_order  ,index);}
-		int   getSector  (int index) { return getInt  (sector_order    ,index);}
-		int   getLayer   (int index) { return getInt  (layer_order     ,index);}
-		float getEnergy  (int index) { return getFloat(energy_order    ,index);}
-		float getLU      (int index) { return getFloat(lu_order        ,index);}
-		float getLV      (int index) { return getFloat(lv_order        ,index);}
-		float getLW      (int index) { return getFloat(lw_order        ,index);}
+		int   getIndex	 (int row) { return getInt  (index_order     ,row);}
+		int   getPindex  (int row) { return getInt  (pindex_order    ,row);}
+		int   getDetector(int row) { return getInt  (detector_order  ,row);}
+		int   getSector  (int row) { return getInt  (sector_order    ,row);}
+		int   getLayer   (int row) { return getInt  (layer_order     ,row);}
+		float getEnergy  (int row) { return getFloat(energy_order    ,row);}
+		float getLU      (int row) { return getFloat(lu_order        ,row);}
+		float getLV      (int row) { return getFloat(lv_order        ,row);}
+		float getLW      (int row) { return getFloat(lw_order        ,row);}
 
+
+		int   getElectronSector  (int pindex);
+		int   getPcalRow( int pindex);
 		float getPcalE (int pindex);
 		float getECinE (int pindex);
 		float getECoutE(int pindex);

--- a/include/BConfig.h
+++ b/include/BConfig.h
@@ -34,15 +34,15 @@ class BConfig : public hipo::bank {
 
 		~BConfig();
 
-		int   getRunNumber (int index) { return getInt ( Run_order        ,index);}
-		int   getEvent     (int index) { return getInt ( Event_order      ,index);}
-		int   getUnixTime  (int index) { return getInt ( UTime_order      ,index);}
-		int   getTrigger   (int index) { return getInt ( Trigger_order    ,index);}
-		int   getTimeStamp (int index) { return getInt ( TimeStamp_order  ,index);}
-		int   getType      (int index) { return getInt ( Type_order       ,index);}
-		int   getMode      (int index) { return getInt ( Mode_order       ,index);}
-		float getTorus     (int index) { return getFloat ( Torus_order    ,index);}
-		float getSolenoid  (int index) { return getFloat ( Solenoid_order ,index);}
+		int   getRunNumber (int row) { return getInt ( Run_order        ,row);}
+		int   getEvent     (int row) { return getInt ( Event_order      ,row);}
+		int   getUnixTime  (int row) { return getInt ( UTime_order      ,row);}
+		int   getTrigger   (int row) { return getInt ( Trigger_order    ,row);}
+		int   getTimeStamp (int row) { return getInt ( TimeStamp_order  ,row);}
+		int   getType      (int row) { return getInt ( Type_order       ,row);}
+		int   getMode      (int row) { return getInt ( Mode_order       ,row);}
+		float getTorus     (int row) { return getFloat ( Torus_order    ,row);}
+		float getSolenoid  (int row) { return getFloat ( Solenoid_order ,row);}
 };
 
 #endif

--- a/include/BEvent.h
+++ b/include/BEvent.h
@@ -35,15 +35,15 @@ class BEvent : public hipo::bank {
 
 		~BEvent();
 
-		int   getCategory(int index) { return getInt   ( Category_order   ,index);}
-		int   getTopo    (int index) { return getInt   ( Topo_order       ,index);}
-		float getBCG     (int index) { return getFloat ( BCG_order        ,index);}
-		float getLT      (int index) { return getFloat ( LiveTime_order   ,index);}
-		float getSTTime  (int index) { return getFloat ( StartTime_order  ,index);}
-		float getRFTime  (int index) { return getFloat ( RFTime_order     ,index);}
-		int   getHelic   (int index) { return getInt   ( Helic_order      ,index);}
-		int   getHelicRaw(int index) { return getInt   ( HelicRaw_order   ,index);}
-		float getPTime   (int index) { return getFloat ( ProcTime_order   ,index);}
+		int   getCategory(int row) { return getInt   ( Category_order   ,row);}
+		int   getTopo    (int row) { return getInt   ( Topo_order       ,row);}
+		float getBCG     (int row) { return getFloat ( BCG_order        ,row);}
+		float getLT      (int row) { return getFloat ( LiveTime_order   ,row);}
+		float getSTTime  (int row) { return getFloat ( StartTime_order  ,row);}
+		float getRFTime  (int row) { return getFloat ( RFTime_order     ,row);}
+		int   getHelic   (int row) { return getInt   ( Helic_order      ,row);}
+		int   getHelicRaw(int row) { return getInt   ( HelicRaw_order   ,row);}
+		float getPTime   (int row) { return getFloat ( ProcTime_order   ,row);}
 };
 
 #endif

--- a/include/BParticle.h
+++ b/include/BParticle.h
@@ -37,21 +37,21 @@ class BParticle : public hipo::bank {
 
 		~BParticle();
 
-		int   getPid    (int index) { return getInt  (pid_order    ,index);}
-		float getPx     (int index) { return getFloat(px_order     ,index);}
-		float getPy     (int index) { return getFloat(py_order     ,index);}
-		float getPz     (int index) { return getFloat(pz_order     ,index);}
-		float getVx     (int index) { return getFloat(vx_order     ,index);}
-	        float getVy     (int index) { return getFloat(vy_order     ,index);}
-	        float getVz     (int index) { return getFloat(vz_order     ,index);}
-	        float getVt     (int index) { return getFloat(vt_order     ,index);}
-		int   getCharge (int index) { return getInt  (charge_order ,index);}
-		float getBeta   (int index) { return getFloat(beta_order   ,index);}
-		float getChi2pid(int index) { return getFloat(chi2pid_order,index);}
-		int   getStatus (int index) { return getInt  (status_order ,index);}
+		int   getPid    (int row) { return getInt  (pid_order    ,row);}
+		float getPx     (int row) { return getFloat(px_order     ,row);}
+		float getPy     (int row) { return getFloat(py_order     ,row);}
+		float getPz     (int row) { return getFloat(pz_order     ,row);}
+		float getVx     (int row) { return getFloat(vx_order     ,row);}
+		float getVy     (int row) { return getFloat(vy_order     ,row);}
+		float getVz     (int row) { return getFloat(vz_order     ,row);}
+		float getVt     (int row) { return getFloat(vt_order     ,row);}
+		int   getCharge (int row) { return getInt  (charge_order ,row);}
+		float getBeta   (int row) { return getFloat(beta_order   ,row);}
+		float getChi2pid(int row) { return getFloat(chi2pid_order,row);}
+		int   getStatus (int row) { return getInt  (status_order ,row);}
 
-		TVector3 getV3v(int index);
-		TVector3 getV3P(int index);
+		TVector3 getV3v(int row);
+		TVector3 getV3P(int row);
 };
 
 #endif

--- a/include/BScaler.h
+++ b/include/BScaler.h
@@ -29,9 +29,9 @@ class BScaler : public hipo::bank {
 		~BScaler();
 
 
-		float getFCupGated (int index) { return getFloat ( FCupGated_order,index);}
-		float getFCup      (int index) { return getFloat ( FCup_order     ,index);}
-		float getLiveTime  (int index) { return getFloat ( LiveTime_order ,index);}
+		float getFCupGated (int row) { return getFloat ( FCupGated_order,row);}
+		float getFCup      (int row) { return getFloat ( FCup_order     ,row);}
+		float getLiveTime  (int row) { return getFloat ( LiveTime_order ,row);}
 };
 
 #endif

--- a/include/BScintillator.h
+++ b/include/BScintillator.h
@@ -42,23 +42,23 @@ class BScintillator : public hipo::bank {
 
 		~BScintillator();
 
-		int   getIndex	  (int index) { return getInt   ( index_order     ,index);}
-		int   getPindex   (int index) { return getInt   ( pindex_order    ,index);}
-		int   getDetector (int index) { return getInt   ( detector_order  ,index);}
-		int   getSector   (int index) { return getInt   ( sector_order    ,index);}
-		int   getLayer    (int index) { return getInt   ( layer_order     ,index);}
-		int   getComponent(int index) { return getInt   ( component_order ,index);}
-		float getEnergy   (int index) { return getFloat ( energy_order    ,index);}
-		float getTime     (int index) { return getFloat ( time_order      ,index);}
-		float getPath     (int index) { return getFloat ( path_order      ,index);}
-		float getChi2     (int index) { return getFloat ( chi2_order      ,index);}
-		float getX        (int index) { return getFloat ( x_order         ,index);}
-		float getY        (int index) { return getFloat ( y_order         ,index);}
-		float getZ        (int index) { return getFloat ( z_order         ,index);}
-		float getHx       (int index) { return getFloat ( hx_order        ,index);}
-		float getHy       (int index) { return getFloat ( hy_order        ,index);}
-		float getHz       (int index) { return getFloat ( hz_order        ,index);}
-		int   getStatus   (int index) { return getInt   ( status_order    ,index);}
+		int   getIndex	  (int row) { return getInt   ( index_order     ,row);}
+		int   getPindex   (int row) { return getInt   ( pindex_order    ,row);}
+		int   getDetector (int row) { return getInt   ( detector_order  ,row);}
+		int   getSector   (int row) { return getInt   ( sector_order    ,row);}
+		int   getLayer    (int row) { return getInt   ( layer_order     ,row);}
+		int   getComponent(int row) { return getInt   ( component_order ,row);}
+		float getEnergy   (int row) { return getFloat ( energy_order    ,row);}
+		float getTime     (int row) { return getFloat ( time_order      ,row);}
+		float getPath     (int row) { return getFloat ( path_order      ,row);}
+		float getChi2     (int row) { return getFloat ( chi2_order      ,row);}
+		float getX        (int row) { return getFloat ( x_order         ,row);}
+		float getY        (int row) { return getFloat ( y_order         ,row);}
+		float getZ        (int row) { return getFloat ( z_order         ,row);}
+		float getHx       (int row) { return getFloat ( hx_order        ,row);}
+		float getHy       (int row) { return getFloat ( hy_order        ,row);}
+		float getHz       (int row) { return getFloat ( hz_order        ,row);}
+		int   getStatus   (int row) { return getInt   ( status_order    ,row);}
 
 };
 

--- a/include/clashit.h
+++ b/include/clashit.h
@@ -11,7 +11,8 @@ class clashit : public TObject {
 
 
 		void Clear();
-		
+		void Print();
+
 		void setSector		(int	iSector		)		{Sector		= iSector	; return;}
 		void setPID		(int	iPID		)		{PID		= iPID		; return;}
 		void setCharge		(int	iCharge		)		{Charge		= iCharge	; return;}
@@ -47,27 +48,27 @@ class clashit : public TObject {
 		void setXb		(double	iXb		)		{Xb		= iXb		; return;}
 		void setW2		(double	iW2		)		{W2		= iW2		; return;}
 
-                void setDC_chi2         (double iDC_chi2      	)		{DC_chi2	= iDC_chi2	; return;}
-                void setDC_NDF		(int    iDC_NDF		)		{DC_NDF 	= iDC_NDF 	; return;}
-                void setDC_sector       (int    iDC_sector      )               {DC_sector      = iDC_sector    ; return;}
+		void setDC_chi2   (double iDC_chi2   	)		{DC_chi2	= iDC_chi2	; return;}
+		void setDC_NDF		(int    iDC_NDF			)		{DC_NDF 	= iDC_NDF 	; return;}
+		void setDC_sector (int    iDC_sector  ) 	{DC_sector      = iDC_sector    ; return;}
 
-                void setDC_x1		(double iDC_x1		)		{DC_x1   	= iDC_x1 	; return;}
-                void setDC_y1		(double iDC_y1		)		{DC_y1   	= iDC_y1   	; return;}
-                void setDC_z1		(double iDC_z1		)		{DC_z1   	= iDC_z1   	; return;}
+		void setDC_x1		(double iDC_x1		)		{DC_x1   	= iDC_x1 	; return;}
+		void setDC_y1		(double iDC_y1		)		{DC_y1   	= iDC_y1   	; return;}
+		void setDC_z1		(double iDC_z1		)		{DC_z1   	= iDC_z1   	; return;}
 
-                void setDC_x2		(double iDC_x2		)		{DC_x2   	= iDC_x2 	; return;}
-                void setDC_y2		(double iDC_y2		)		{DC_y2   	= iDC_y2   	; return;}
-                void setDC_z2		(double iDC_z2		)		{DC_z2   	= iDC_z2   	; return;}
+		void setDC_x2		(double iDC_x2		)		{DC_x2   	= iDC_x2 	; return;}
+		void setDC_y2		(double iDC_y2		)		{DC_y2   	= iDC_y2   	; return;}
+		void setDC_z2		(double iDC_z2		)		{DC_z2   	= iDC_z2   	; return;}
 
-                void setDC_x3		(double iDC_x3		)		{DC_x3   	= iDC_x3 	; return;}
-                void setDC_y3		(double iDC_y3		)		{DC_y3   	= iDC_y3   	; return;}
-                void setDC_z3		(double iDC_z3		)		{DC_z3   	= iDC_z3   	; return;}
+		void setDC_x3		(double iDC_x3		)		{DC_x3   	= iDC_x3 	; return;}
+		void setDC_y3		(double iDC_y3		)		{DC_y3   	= iDC_y3   	; return;}
+		void setDC_z3		(double iDC_z3		)		{DC_z3   	= iDC_z3   	; return;}
 
 		int	getSector	(void)		{return Sector		;}
 		int	getPID		(void)		{return PID		;}
 		int	getCharge	(void)		{return Charge		;}
 		int	getStatus	(void)		{return Status		;}
-                                                                
+
 		double	getTime		(void)		{return Time		;}
 		double	getBeta		(void)		{return Beta		;}
 		double	getChi2		(void)		{return Chi2		;}
@@ -84,42 +85,42 @@ class clashit : public TObject {
 		double	getVtx		(void)		{return Vtx		;}
 		double	getVty		(void)		{return Vty		;}
 		double	getVtz		(void)		{return Vtz		;}
-                                                                
+
 		double	getMomentum	(void)		{return Momentum	;}
 		double	getTheta	(void)		{return Theta		;}
 		double	getPhi		(void)		{return Phi		;}
-                                                               
+
 		double	getQ		(void)		{return Q		;}
 		double	getThetaQ	(void)		{return ThetaQ		;}
 		double	getPhiQ		(void)		{return PhiQ		;}
-                                                              
+
 		double	getQ2		(void)		{return Q2		;}
 		double	getOmega	(void)		{return Omega		;}
 		double	getXb		(void)		{return Xb		;}
 		double	getW2		(void)		{return W2		;}
 
 
-                double  getDC_chi2      (void)          {return DC_chi2         ;}
-                int     getDC_NDF       (void)          {return DC_NDF          ;}
-                int     getDC_sector    (void)          {return DC_sector       ;}
+		double  getDC_chi2      (void)          {return DC_chi2         ;}
+		int     getDC_NDF       (void)          {return DC_NDF          ;}
+		int     getDC_sector    (void)          {return DC_sector       ;}
 
-                double  getDC_x1        (void)          {return DC_x1           ;}
-                double  getDC_y1        (void)          {return DC_y1           ;}
-                double  getDC_z1        (void)          {return DC_z1           ;}
+		double  getDC_x1        (void)          {return DC_x1           ;}
+		double  getDC_y1        (void)          {return DC_y1           ;}
+		double  getDC_z1        (void)          {return DC_z1           ;}
 
-                double  getDC_x2        (void)          {return DC_x2           ;}
-                double  getDC_y2        (void)          {return DC_y2           ;}
-                double  getDC_z2        (void)          {return DC_z2           ;}
+		double  getDC_x2        (void)          {return DC_x2           ;}
+		double  getDC_y2        (void)          {return DC_y2           ;}
+		double  getDC_z2        (void)          {return DC_z2           ;}
 
-                double  getDC_x3        (void)          {return DC_x3           ;}
-                double  getDC_y3        (void)          {return DC_y3           ;}
-                double  getDC_z3        (void)          {return DC_z3           ;}
+		double  getDC_x3        (void)          {return DC_x3           ;}
+		double  getDC_y3        (void)          {return DC_y3           ;}
+		double  getDC_z3        (void)          {return DC_z3           ;}
 
-		  ClassDef(clashit,2);
+		ClassDef(clashit,3);
 
 	private:
 		int	Sector		;
-		int 	PID		;
+		int PID		;
 		int	Charge		;
 		int	Status		;
 
@@ -143,7 +144,7 @@ class clashit : public TObject {
 		double 	Momentum	;
 		double	Theta		;
 		double 	Phi		;
-		
+
 		double 	Q		;
 		double	ThetaQ		;
 		double 	PhiQ		;
@@ -153,21 +154,21 @@ class clashit : public TObject {
 		double	Xb		;
 		double	W2		;
 
-                double DC_chi2          ;
-                int    DC_NDF           ;
-                int    DC_sector        ;
+		double DC_chi2          ;
+		int    DC_NDF           ;
+		int    DC_sector        ;
 
-                double DC_x1            ;
-                double DC_y1            ;
-                double DC_z1            ;
+		double DC_x1            ;
+		double DC_y1            ;
+		double DC_z1            ;
 
-                double DC_x2            ;
-                double DC_y2            ;
-                double DC_z2            ;
+		double DC_x2            ;
+		double DC_y2            ;
+		double DC_z2            ;
 
-                double DC_x3            ;
-                double DC_y3            ;
-                double DC_z3            ;
+		double DC_x3            ;
+		double DC_y3            ;
+		double DC_z3            ;
 };
 
 

--- a/skimmers/readhipo_helper.cpp
+++ b/skimmers/readhipo_helper.cpp
@@ -390,9 +390,10 @@ void getElectronInfo( BParticle particles, BCalorimeter calorimeter, BScintillat
 	TVector3 	beamVec(0,0,Ebeam);
 	TVector3	qVec; qVec = beamVec - momentum;
 
-
-	electron.setSector		(	calorimeter.getSector(0)				);
-	electron.setPID			(	particles.getPid(0)					);
+//for Calorimeter information it is the Particle bank index for the first particle (usually electron)
+//for Particle bank it is bank index 0
+	electron.setSector		(	calorimeter.getElectronSector(0)				);
+	electron.setPID			  (	particles.getPid(0)					);
 	electron.setCharge		(	particles.getCharge(0)					);
 	electron.setStatus		(	particles.getStatus(0)					);
 
@@ -404,11 +405,11 @@ void getElectronInfo( BParticle particles, BCalorimeter calorimeter, BScintillat
 	electron.setEecin		(	calorimeter.getECinE(0)					);
 	electron.setEecout		(	calorimeter.getECoutE(0)       				);
 	electron.setEoP			(	electron.getEtot() / momentum.Mag()			);
-	electron.setTimeScint		(	scintillator.getTime(0)-starttime			);
-	electron.setPathScint		(	scintillator.getPath(0)					);
-	electron.setU			(	calorimeter.getLU(0)					);
-	electron.setV			(	calorimeter.getLV(0)					);
-	electron.setW			(	calorimeter.getLW(0)					);
+	if (calorimeter.getPcalRow(0) > -1) {
+		electron.setU			(	calorimeter.getLU(calorimeter.getPcalRow(0))					);
+		electron.setV			(	calorimeter.getLV(calorimeter.getPcalRow(0))					);
+		electron.setW			(	calorimeter.getLW(calorimeter.getPcalRow(0))					);
+	}
 	electron.setVtx			(	vertex.X()						);
 	electron.setVty			(	vertex.Y()						);
 	electron.setVtz			(	vertex.Z()						);
@@ -427,7 +428,7 @@ void getElectronInfo( BParticle particles, BCalorimeter calorimeter, BScintillat
 	electron.setW2			(	mP*mP - electron.getQ2() + 2.*electron.getOmega()*mP	);
 
 
-        //Adding Tracking bank
+  //Adding Tracking bank
 
 	int Ntrack = DC_Track.getRows();
 	int index = -1;
@@ -448,9 +449,19 @@ void getElectronInfo( BParticle particles, BCalorimeter calorimeter, BScintillat
 	if (index != -1 && count ==1) {
 	  electron.setDC_chi2             (       DC_Track.getFloat(6, index)                                 );
 	  electron.setDC_NDF              (       DC_Track.getInt(7, index)                                   );
-          electron.setDC_sector           (       DC_Track.getInt(3, index)                                   );
+	  electron.setDC_sector           (       DC_Track.getInt(3, index)                                   );
 
 	}
+	else {
+		electron.setDC_sector           (       electron.getSector()                                );
+	}
+	if (count>1) {
+		cout << "getElectronInfo Warning: DC count is larger than 1. Count =  " << count << endl;
+	}
+	if (index == -1) {
+		cout << "getElectronInfo Warning: DC index is -1" << endl;
+	}
+
 
 
 	//Adding Traj bank, Structure is more complicated
@@ -460,7 +471,7 @@ void getElectronInfo( BParticle particles, BCalorimeter calorimeter, BScintillat
 	int index_traj = -1;
 
 	for(int i =0; i <NTraj; i++){
-          int pindex   = DC_Traj.getInt(0, i);
+    int pindex   = DC_Traj.getInt(0, i);
 	  int detector = DC_Traj.getInt(2,i);
 	  int layer    = DC_Traj.getInt(3,i);
 


### PR DESCRIPTION
- Changed banklib classes to use consistently a call to row.
- BCalorimeter:
	* Added check of EC detector ID to getPcal, getECin and getECout functions
	* Add getPcalRow which gives back the row entry corresponding to PCAL for a given particle index
	* Add getElectronSector which gives back Sector id of PCAL for a given particle index (usually 0 = electron)
- clashit has now a print function. Also changed Sector initial value to -1
- getElectronInfo:
	* Uses new BCalorimeter function to determine correctly sector and U, V, W for a given pindex
	* Extra checks and warning if tracking bank index==-1 or count !=1. Use electron sector instead of DC sector in this case
	* Time and Path from Scintillator is not saved anymore in clashit.
- e_pid: Add check if EPcal, EECin or EoverP is 0 return false for passing PID