### PR TITLE
- Fixed reading of TDC and FADC offsets for different run periods in …

### DIFF
--- a/skimmers/ncalibration.cpp
+++ b/skimmers/ncalibration.cpp
@@ -77,22 +77,10 @@ int main(int argc, char** argv) {
 	// Connect to the RCDB
 	rcdb::Connection connection("mysql://rcdb@clasdb.jlab.org/rcdb");
 
-	//Load bar shifts
+	//Load Bar shifts
 	shiftsReader shifts;
-	double * FADC_BARSHIFTS_LER;
-	double * TDC_BARSHIFTS_LER;
-	double * FADC_BARSHIFTS_SPRING19;
-	double * TDC_BARSHIFTS_SPRING19;
-	if( loadshifts_opt ){
-		shifts.LoadInitBarFadc("../include/LER_FADC_shifts.txt");
-		FADC_BARSHIFTS_LER = (double*) shifts.getInitBarFadc();
-		shifts.LoadInitBar("../include/LER_TDC_shifts.txt");
-		TDC_BARSHIFTS_LER = (double*) shifts.getInitBar();
-		shifts.LoadInitBarFadc	("../include/FADC_pass1v0_initbar.txt");
-		FADC_BARSHIFTS_SPRING19 = (double*) shifts.getInitBarFadc();
-		shifts.LoadInitBar	("../include/TDC_pass1v0_initbar.txt");
-		TDC_BARSHIFTS_SPRING19 = (double*) shifts.getInitBar();
-	}
+	double * FADC_BARSHIFTS;
+	double * TDC_BARSHIFTS;
 
 	// Effective velocity for re-doing x- calculation
 	double * FADC_EFFVEL_S6200;
@@ -184,6 +172,7 @@ int main(int argc, char** argv) {
 		int event_counter = 0;
 		gated_charge 	= 0;
 		livetime	= 0;
+		int run_number_from_run_config = 0;
 		double torussetting = 0;
 		while(reader.next()==true){
 			// Clear all branches
@@ -223,9 +212,34 @@ int main(int argc, char** argv) {
 			readevent.getStructure(DC_Track);
 			readevent.getStructure(DC_Traj);
 
-			//Get Event number from RUN::config
-			eventnumber = run_config.getInt( 1 , 0 );
 
+			//Get Event number and run number from RUN::config
+			run_number_from_run_config = run_config.getInt( 0 , 0 );
+			eventnumber = run_config.getInt( 1 , 0 );
+			if (run_number_from_run_config != Runno && event_counter < 100) {
+					cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
+			}
+
+			if( loadshifts_opt && event_counter == 1 && MC_DATA_OPT !=0){
+				//Load of shifts depending on run number
+				if (Runno >= 11286 && Runno < 11304)	{ //LER runs
+					shifts.LoadInitBarFadc("../include/LER_FADC_shifts.txt");
+					FADC_BARSHIFTS = (double*) shifts.getInitBarFadc();
+					shifts.LoadInitBar("../include/LER_TDC_shifts.txt");
+					TDC_BARSHIFTS = (double*) shifts.getInitBar();
+				}
+				else if (Runno > 6100 && Runno < 6800) { //Spring 19 data
+					shifts.LoadInitBarFadc	("../include/FADC_pass1v0_initbar.txt");
+					FADC_BARSHIFTS = (double*) shifts.getInitBarFadc();
+					shifts.LoadInitBar	("../include/TDC_pass1v0_initbar.txt");
+					TDC_BARSHIFTS = (double*) shifts.getInitBar();
+				}
+				else {
+					cout << "No bar by bar offsets loaded " << endl;
+					cout << "Check shift option when starting program. Exit " << endl;
+					exit(-1);
+				}
+			}
 
 			//from first event get RUN::config torus Setting
 			// inbending = negative torussetting, outbending = torusseting
@@ -317,20 +331,10 @@ int main(int argc, char** argv) {
 							FADC_EFFVEL_S6291,	TDC_EFFVEL_S6291	);
 			}
 			if( loadshifts_opt && MC_DATA_OPT !=0){
-				//Load of shifts depending on run number
-				if (Runno >= 11286 && Runno < 11304)	{
-					//LER corrections
 					for( int n = 0 ; n < nMult ; n++ ){
-						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS_LER[(int)nHit[n].getBarID()] );
-						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS_LER[(int)nHit[n].getBarID()]  );
+						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS[(int)nHit[n].getBarID()] );
+						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS[(int)nHit[n].getBarID()]  );
 					}
-				}
-				else if (Runno > 6100 && Runno < 6800) { //Spring 19 data
-					for( int n = 0 ; n < nMult ; n++ ){
-						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS_SPRING19[(int)nHit[n].getBarID()] );
-						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS_SPRING19[(int)nHit[n].getBarID()]  );
-					}
-				}
 			}
 
 			// Store the neutrons in TClonesArray

--- a/skimmers/neutrons.cpp
+++ b/skimmers/neutrons.cpp
@@ -86,22 +86,10 @@ int main(int argc, char** argv) {
 	// Connect to the RCDB
 	rcdb::Connection connection("mysql://rcdb@clasdb.jlab.org/rcdb");
 
-	//Load bar shifts
+	//Load Bar shifts
 	shiftsReader shifts;
-	double * FADC_BARSHIFTS_LER;
-	double * TDC_BARSHIFTS_LER;
-	double * FADC_BARSHIFTS_SPRING19;
-	double * TDC_BARSHIFTS_SPRING19;
-	if( loadshifts_opt ){
-		shifts.LoadInitBarFadc("../include/LER_FADC_shifts.txt");
-		FADC_BARSHIFTS_LER = (double*) shifts.getInitBarFadc();
-		shifts.LoadInitBar("../include/LER_TDC_shifts.txt");
-		TDC_BARSHIFTS_LER = (double*) shifts.getInitBar();
-		shifts.LoadInitBarFadc	("../include/FADC_pass1v0_initbar.txt");
-		FADC_BARSHIFTS_SPRING19 = (double*) shifts.getInitBarFadc();
-		shifts.LoadInitBar	("../include/TDC_pass1v0_initbar.txt");
-		TDC_BARSHIFTS_SPRING19 = (double*) shifts.getInitBar();
-	}
+	double * FADC_BARSHIFTS;
+	double * TDC_BARSHIFTS;
 
 	// Effective velocity for re-doing x- calculation
 	double * FADC_EFFVEL_S6200;
@@ -190,6 +178,7 @@ int main(int argc, char** argv) {
 		int event_counter = 0;
 		gated_charge = 0;
 		livetime	= 0;
+		int run_number_from_run_config = 0;
 		double torussetting = 0;
 		while(reader.next()==true){
 			// Clear all branches
@@ -227,12 +216,38 @@ int main(int argc, char** argv) {
 			readevent.getStructure(mc_event_info);
 			readevent.getStructure(mc_particle);
 
-			//Get Event number from RUN::config
+			//Get Event number and run number from RUN::config
+			run_number_from_run_config = run_config.getInt( 0 , 0 );
 			eventnumber = run_config.getInt( 1 , 0 );
+			if (run_number_from_run_config != Runno && event_counter < 100) {
+				cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
+			}
 
 			//from first event get RUN::config torus Setting
 		 // inbending = negative torussetting, outbending = torusseting
 			torussetting = run_config.getFloat( 7 , 0 );
+
+			if( loadshifts_opt && event_counter == 1 && MC_DATA_OPT !=0){
+				//Load of shifts depending on run number
+				if (Runno >= 11286 && Runno < 11304)	{ //LER runs
+					shifts.LoadInitBarFadc("../include/LER_FADC_shifts.txt");
+					FADC_BARSHIFTS = (double*) shifts.getInitBarFadc();
+					shifts.LoadInitBar("../include/LER_TDC_shifts.txt");
+					TDC_BARSHIFTS = (double*) shifts.getInitBar();
+				}
+				else if (Runno > 6100 && Runno < 6800) { //Spring 19 data
+					shifts.LoadInitBarFadc	("../include/FADC_pass1v0_initbar.txt");
+					FADC_BARSHIFTS = (double*) shifts.getInitBarFadc();
+					shifts.LoadInitBar	("../include/TDC_pass1v0_initbar.txt");
+					TDC_BARSHIFTS = (double*) shifts.getInitBar();
+				}
+				else {
+					cout << "No bar by bar offsets loaded " << endl;
+					cout << "Check shift option when starting program. Exit " << endl;
+					exit(-1);
+				}
+			}
+
 
 			// For simulated events, get the weight for the event
 			if( MC_DATA_OPT == 0){
@@ -256,20 +271,10 @@ int main(int argc, char** argv) {
 			}
 
 			if( loadshifts_opt && MC_DATA_OPT !=0){
-				//Load of shifts depending on run number
-				if (Runno >= 11286 && Runno < 11304)	{
-					//LER corrections
 					for( int n = 0 ; n < nMult ; n++ ){
-						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS_LER[(int)nHit[n].getBarID()] );
-						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS_LER[(int)nHit[n].getBarID()]  );
+						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS[(int)nHit[n].getBarID()] );
+						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS[(int)nHit[n].getBarID()]  );
 					}
-				}
-				else if (Runno > 6100 && Runno < 6800) { //Spring 19 data
-					for( int n = 0 ; n < nMult ; n++ ){
-						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS_SPRING19[(int)nHit[n].getBarID()] );
-						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS_SPRING19[(int)nHit[n].getBarID()]  );
-					}
-				}
 			}
 
 			// Store the neutrons in TClonesArray

--- a/skimmers/quasielastic.cpp
+++ b/skimmers/quasielastic.cpp
@@ -170,20 +170,9 @@ int main(int argc, char** argv) {
 	//Load Bar shifts
 	//TODO: Make shifts flexible to use
 	shiftsReader shifts;
-	double * FADC_BARSHIFTS_LER;
-	double * TDC_BARSHIFTS_LER;
-	double * FADC_BARSHIFTS_SPRING19;
-	double * TDC_BARSHIFTS_SPRING19;
-	if( loadshifts_opt ){
-		shifts.LoadInitBarFadc("../include/LER_FADC_shifts.txt");
-		FADC_BARSHIFTS_LER = (double*) shifts.getInitBarFadc();
-		shifts.LoadInitBar("../include/LER_TDC_shifts.txt");
-		TDC_BARSHIFTS_LER = (double*) shifts.getInitBar();
-		shifts.LoadInitBarFadc	("../include/FADC_pass1v0_initbar.txt");
-		FADC_BARSHIFTS_SPRING19 = (double*) shifts.getInitBarFadc();
-		shifts.LoadInitBar	("../include/TDC_pass1v0_initbar.txt");
-		TDC_BARSHIFTS_SPRING19 = (double*) shifts.getInitBar();
-	}
+	double * FADC_BARSHIFTS;
+	double * TDC_BARSHIFTS;
+
 	/*
 		double * FADC_INITRUN;
 		// Load run-by-run shifts
@@ -380,6 +369,28 @@ int main(int argc, char** argv) {
 			}
 
 
+			if( loadshifts_opt && event_counter == 1 && MC_DATA_OPT !=0){
+				//Load of shifts depending on run number
+				if (Runno >= 11286 && Runno < 11304)	{ //LER runs
+					shifts.LoadInitBarFadc("../include/LER_FADC_shifts.txt");
+					FADC_BARSHIFTS = (double*) shifts.getInitBarFadc();
+					shifts.LoadInitBar("../include/LER_TDC_shifts.txt");
+					TDC_BARSHIFTS = (double*) shifts.getInitBar();
+				}
+				else if (Runno > 6100 && Runno < 6800) { //Spring 19 data
+					shifts.LoadInitBarFadc	("../include/FADC_pass1v0_initbar.txt");
+					FADC_BARSHIFTS = (double*) shifts.getInitBarFadc();
+					shifts.LoadInitBar	("../include/TDC_pass1v0_initbar.txt");
+					TDC_BARSHIFTS = (double*) shifts.getInitBar();
+				}
+				else {
+					cout << "No bar by bar offsets loaded " << endl;
+					cout << "Check shift option when starting program. Exit " << endl;
+					exit(-1);
+				}
+
+			}
+
 			//from first event get RUN::config torus Setting
 		 // inbending = negative torussetting, outbending = torusseting
 			torussetting = run_config.getFloat( 7 , 0 );
@@ -480,20 +491,10 @@ int main(int argc, char** argv) {
 			}
 
 			if( loadshifts_opt && MC_DATA_OPT !=0){
-				//Load of shifts depending on run number
-				if (Runno >= 11286 && Runno < 11304)	{
-					//LER corrections
 					for( int n = 0 ; n < nMult ; n++ ){
-						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS_LER[(int)nHit[n].getBarID()] );
-						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS_LER[(int)nHit[n].getBarID()]  );
+						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS[(int)nHit[n].getBarID()] );
+						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS[(int)nHit[n].getBarID()]  );
 					}
-				}
-				else if (Runno > 6100 && Runno < 6800) { //Spring 19 data
-					for( int n = 0 ; n < nMult ; n++ ){
-						nHit[n].setTofFadc(	nHit[n].getTofFadc() 	- FADC_BARSHIFTS_SPRING19[(int)nHit[n].getBarID()] );
-						nHit[n].setTof(		nHit[n].getTof() 	- TDC_BARSHIFTS_SPRING19[(int)nHit[n].getBarID()]  );
-					}
-				}
 			}
 
 


### PR DESCRIPTION
…QE, ncalibration and neutron skimmer. In the previous version LER offsets were overwritten by Spring 19 offsets. Updated code now read the offsets for each run after Runno it set. To avoid multiple reading of the offsets, this is done just for the first event in the loop
- Also add check of Run number from RUN::config for neutron and nacalibration skimmer