### PR TITLE
- Reorder neutron shift load, REC::Event check and Run numer check in…

### DIFF
--- a/skimmers/ncalibration.cpp
+++ b/skimmers/ncalibration.cpp
@@ -212,14 +212,6 @@ int main(int argc, char** argv) {
 			readevent.getStructure(DC_Track);
 			readevent.getStructure(DC_Traj);
 
-
-			//Get Event number and run number from RUN::config
-			run_number_from_run_config = run_config.getInt( 0 , 0 );
-			eventnumber = run_config.getInt( 1 , 0 );
-			if (run_number_from_run_config != Runno && event_counter < 100) {
-					cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
-			}
-
 			if( loadshifts_opt && event_counter == 1 && MC_DATA_OPT !=0){
 				//Load of shifts depending on run number
 				if (Runno >= 11286 && Runno < 11304)	{ //LER runs
@@ -241,13 +233,22 @@ int main(int argc, char** argv) {
 				}
 			}
 
+			// Get integrated charge, livetime and start-time from REC::Event
+			//Currently, REC::Event has uncalibrated livetime / charge, so these will have to work
+			if( event_info.getRows() == 0 ) continue;
+			getEventInfo( event_info, gated_charge, livetime, starttime );
+
+			//Get Event number and run number from RUN::config
+			run_number_from_run_config = run_config.getInt( 0 , 0 );
+			eventnumber = run_config.getInt( 1 , 0 );
+			if (run_number_from_run_config != Runno && event_counter < 100) {
+				cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
+			}
+
+
 			//from first event get RUN::config torus Setting
 			// inbending = negative torussetting, outbending = torusseting
 			torussetting = run_config.getFloat( 7 , 0 );
-
-			// Get integrated charge, livetime and start-time from REC::Event
-			if( event_info.getRows() == 0 ) continue;
-			getEventInfo( event_info, gated_charge, livetime, starttime );
 
 			// Skim the event so we only have a single electron and NO other particles:
 			int nElectrons = 0;
@@ -287,7 +288,7 @@ int main(int argc, char** argv) {
 			if( !(ePID.isElectron(&eHit)) ) continue;
 
 			//Skip sector 4 events for LER runs
-			if (Runno >= 11286 && Runno < 11304 && eHit.getSector() == 4)	{ 
+			if (Runno >= 11286 && Runno < 11304 && eHit.getSector() == 4)	{
 				continue;
 			}
 

--- a/skimmers/neutrons.cpp
+++ b/skimmers/neutrons.cpp
@@ -216,17 +216,6 @@ int main(int argc, char** argv) {
 			readevent.getStructure(mc_event_info);
 			readevent.getStructure(mc_particle);
 
-			//Get Event number and run number from RUN::config
-			run_number_from_run_config = run_config.getInt( 0 , 0 );
-			eventnumber = run_config.getInt( 1 , 0 );
-			if (run_number_from_run_config != Runno && event_counter < 100) {
-				cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
-			}
-
-			//from first event get RUN::config torus Setting
-		 // inbending = negative torussetting, outbending = torusseting
-			torussetting = run_config.getFloat( 7 , 0 );
-
 			if( loadshifts_opt && event_counter == 1 && MC_DATA_OPT !=0){
 				//Load of shifts depending on run number
 				if (Runno >= 11286 && Runno < 11304)	{ //LER runs
@@ -249,14 +238,27 @@ int main(int argc, char** argv) {
 			}
 
 
+			// Get integrated charge, livetime and start-time from REC::Event
+			//Currently, REC::Event has uncalibrated livetime / charge, so these will have to work
+			if( event_info.getRows() == 0 ) continue;
+			getEventInfo( event_info, gated_charge, livetime, starttime );
+
+			//Get Event number and run number from RUN::config
+			run_number_from_run_config = run_config.getInt( 0 , 0 );
+			eventnumber = run_config.getInt( 1 , 0 );
+			if (run_number_from_run_config != Runno && event_counter < 100) {
+				cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
+			}
+
+
+			//from first event get RUN::config torus Setting
+			// inbending = negative torussetting, outbending = torusseting
+			torussetting = run_config.getFloat( 7 , 0 );
+
 			// For simulated events, get the weight for the event
 			if( MC_DATA_OPT == 0){
 				getMcInfo( mc_particle , mc_event_info , mcPart , starttime, weight, Ebeam , genMult );
 			}
-
-			// Get integrated charge, livetime and start-time from REC::Event
-			if( event_info.getRows() == 0 ) continue;
-			getEventInfo( event_info, gated_charge, livetime, starttime );
 
 			// Grab the neutron information:
 			if( MC_DATA_OPT == 0 ){

--- a/skimmers/quasielastic.cpp
+++ b/skimmers/quasielastic.cpp
@@ -356,19 +356,6 @@ int main(int argc, char** argv) {
 			readevent.getStructure(mc_event_info);
 			readevent.getStructure(mc_particle);
 
-			// Get integrated charge, livetime and start-time from REC::Event
-			//Currently, REC::Event has uncalibrated livetime / charge, so these will have to work
-			if( event_info.getRows() == 0 ) continue;
-			getEventInfo( event_info, gated_charge, livetime, starttime );
-
-			//Get Event number and run number from RUN::config
-			run_number_from_run_config = run_config.getInt( 0 , 0 );
-			eventnumber = run_config.getInt( 1 , 0 );
-			if (run_number_from_run_config != Runno && event_counter < 100) {
-				cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
-			}
-
-
 			if( loadshifts_opt && event_counter == 1 && MC_DATA_OPT !=0){
 				//Load of shifts depending on run number
 				if (Runno >= 11286 && Runno < 11304)	{ //LER runs
@@ -389,6 +376,19 @@ int main(int argc, char** argv) {
 					exit(-1);
 				}
 
+			}
+
+
+			// Get integrated charge, livetime and start-time from REC::Event
+			//Currently, REC::Event has uncalibrated livetime / charge, so these will have to work
+			if( event_info.getRows() == 0 ) continue;
+			getEventInfo( event_info, gated_charge, livetime, starttime );
+
+			//Get Event number and run number from RUN::config
+			run_number_from_run_config = run_config.getInt( 0 , 0 );
+			eventnumber = run_config.getInt( 1 , 0 );
+			if (run_number_from_run_config != Runno && event_counter < 100) {
+				cout << "Run number from RUN::config and file name not the same!! File name is " << Runno << " and RUN::config is " << run_number_from_run_config << endl;
 			}
 
 			//from first event get RUN::config torus Setting


### PR DESCRIPTION
… neutron, ncalibration and QE skimmer. Order is now consistent and avoids any REC::Event or Runnumber check before Shifts are loaded