### PR TITLE
- Implement MC smearing function from RGA in readhipo_helper.cpp

### DIFF
--- a/include/readhipo_helper.h
+++ b/include/readhipo_helper.h
@@ -15,6 +15,7 @@
 #include "clashit.h"
 #include "taghit.h"
 #include "genpart.h"
+#include "TRandom3.h"
 
 using namespace std;
 
@@ -89,5 +90,8 @@ void getParticleInfo( BParticle particles, int pid[maxParticles], TVector3 momen
 								double time[maxParticles], int charge[maxParticles], double beta[maxParticles], double chi2pid[maxParticles], int status[maxParticles] , int index[maxParticles], int& multiplicity );
 void getBANDBarGeometry(string filename, std::map<int,double> &bar_x, std::map<int,double> &bar_y, std::map<int,double> &bar_z);
 void getBANDEdepCalibration(string filename, std::map<int,double> &bar_edep);
+//Parametrization from Giovanni (GWU) and FX based on double pion analysis in RGA
+void smearRGA(TVector3 &vpar);
+void recalculate_clashit_kinematics(clashit &input_ehit, double Ebeam, TVector3 &smeared_electron);
 
 #endif

--- a/skimmers/electrons.cpp
+++ b/skimmers/electrons.cpp
@@ -60,6 +60,8 @@ int main(int argc, char** argv) {
 	TClonesArray &saveMC = *mcParts;
 	//	Electron info:
 	clashit eHit;
+	//Smeared info
+	clashit eHit_smeared;
 	// 	Event branches:
 	outTree->Branch("Runno"		,&Runno			);
 	outTree->Branch("Ebeam"		,&Ebeam			);
@@ -75,6 +77,10 @@ int main(int argc, char** argv) {
 	//	MC branches:
 	outTree->Branch("genMult"	,&genMult		);
 	outTree->Branch("mcParts"	,&mcParts		);
+	if( MC_DATA_OPT == 0 ){ // if this is a MC file, define smeared branches
+		//	Smeared Electron branches:
+		outTree->Branch("eHit_smeared"		,&eHit_smeared			);
+	}
 
 
 	// Connect to the RCDB
@@ -141,6 +147,10 @@ int main(int argc, char** argv) {
 			genMult 	= 0;
 			genpart mcPart[maxGens];
 			mcParts->Clear();
+			if( MC_DATA_OPT == 0 ){ // if this is a MC file, clear smeared and input branches
+				//Clear output smear branches
+				eHit_smeared.Clear();
+			}
 
 			// Count events
 			if(event_counter%1000000==0) cout << "event: " << event_counter << endl;
@@ -214,6 +224,22 @@ int main(int argc, char** argv) {
 			//check if any of the fiducials is false i.e. electron does not pass all DC fiducials
 			if (!DC_fid_1 || !DC_fid_2 || !DC_fid_3) continue;
 
+
+			//MC smearing
+			if( MC_DATA_OPT == 0 ){ // if this is a MC file, do smearing and add values
+
+				// Grab the electron information for the smeared eHit Object
+				getElectronInfo( particles , calorimeter , scintillator , DC_Track, DC_Traj, 0, eHit_smeared , starttime , Runno , Ebeam );
+
+				//read electron vector
+				TVector3 reco_electron(0,0,0);
+				reco_electron.SetMagThetaPhi(eHit.getMomentum(),eHit.getTheta(),eHit.getPhi());
+				//Smear Reconstructed electron in Momentum, Theta and Phi
+				smearRGA(reco_electron);
+
+				//Recalculate Electron Kinematics with smeared values
+				recalculate_clashit_kinematics(eHit_smeared, Ebeam, reco_electron);
+			}
 
 			// Store the mc particles in TClonesArray
 			for( int n = 0 ; n < maxGens ; n++ ){

--- a/skimmers/tagged_dis.cpp
+++ b/skimmers/tagged_dis.cpp
@@ -232,6 +232,7 @@ int main(int argc, char** argv) {
 			nHits->Clear();
 			// Tag
 			taghit tag[maxNeutrons];
+			taghit tag_smeared[maxNeutrons];
 			tags->Clear();
 			// Electron
 			eHit.Clear();
@@ -378,8 +379,6 @@ int main(int argc, char** argv) {
 
 				//Recalculate Electron Kinematics with smeared values
 				recalculate_clashit_kinematics(eHit_smeared, Ebeam, reco_electron);
-
-				taghit tag_smeared[maxNeutrons];
 
 				// Create the tagged smeared information from the smeared electron and neutron information:
 				getTaggedInfo(	eHit_smeared	,  nHit	 ,  tag_smeared , Ebeam , nMult );

--- a/skimmers/tagged_dis.cpp
+++ b/skimmers/tagged_dis.cpp
@@ -72,6 +72,11 @@ int main(int argc, char** argv) {
 	//	Tagged info:
 	TClonesArray * tags = new TClonesArray("taghit");
 	TClonesArray &saveTags = *tags;
+	//Smeared info
+	clashit eHit_smeared;
+	//	Smeared Tagged info:
+	TClonesArray * tags_smeared = new TClonesArray("taghit");
+	TClonesArray &saveTags_smeared = *tags_smeared;
 	// 	Event branches:
 	outTree->Branch("Runno"		,&Runno			);
 	outTree->Branch("Ebeam"		,&Ebeam			);
@@ -94,6 +99,13 @@ int main(int argc, char** argv) {
 	//	MC branches:
 	outTree->Branch("genMult"	,&genMult		);
 	outTree->Branch("mcParts"	,&mcParts		);
+	if( MC_DATA_OPT == 0 ){ // if this is a MC file, define smeared branches
+		//	Smeared Electron branches:
+		outTree->Branch("eHit_smeared"		,&eHit_smeared			);
+		//	Smeared Tagged branches:
+		outTree->Branch("tag_smeared"		,&tags_smeared			);
+	}
+
 
 	// Connect to the RCDB
 	rcdb::Connection connection("mysql://rcdb@clasdb.jlab.org/rcdb");
@@ -228,7 +240,11 @@ int main(int argc, char** argv) {
 			weight = 1;
 			genpart mcPart[maxGens];
 			mcParts->Clear();
-
+			if( MC_DATA_OPT == 0 ){ // if this is a MC file, clear smeared and input branches
+				//Clear output smear branches
+				eHit_smeared.Clear();
+				tags_smeared->Clear();
+			}
 
 			// Count events
 			if(event_counter%10000==0) cout << "event: " << event_counter << endl;
@@ -347,6 +363,32 @@ int main(int argc, char** argv) {
 
 			// Create the tagged information if we have neutrons appropriately aligned in time:
 			getTaggedInfo(	eHit	,  nHit	 ,  tag  , Ebeam , nMult );
+
+			//MC smearing
+			if( MC_DATA_OPT == 0 ){ // if this is a MC file, do smearing and add values
+
+				// Grab the electron information for the smeared eHit Object
+				getElectronInfo( particles , calorimeter , scintillator , DC_Track, DC_Traj, 0, eHit_smeared , starttime , Runno , Ebeam );
+
+				//read electron vector
+				TVector3 reco_electron(0,0,0);
+				reco_electron.SetMagThetaPhi(eHit.getMomentum(),eHit.getTheta(),eHit.getPhi());
+				//Smear Reconstructed electron in Momentum, Theta and Phi
+				smearRGA(reco_electron);
+
+				//Recalculate Electron Kinematics with smeared values
+				recalculate_clashit_kinematics(eHit_smeared, Ebeam, reco_electron);
+
+				taghit tag_smeared[maxNeutrons];
+
+				// Create the tagged smeared information from the smeared electron and neutron information:
+				getTaggedInfo(	eHit_smeared	,  nHit	 ,  tag_smeared , Ebeam , nMult );
+
+				for( int n = 0 ; n < nMult ; n++ ){
+					new(saveTags_smeared[n]) taghit;
+					saveTags_smeared[n] = &tag_smeared[n];
+					}
+			}
 
 			// Store the neutrons in TClonesArray
 			for( int n = 0 ; n < nMult ; n++ ){


### PR DESCRIPTION
- Add recalculation of electron kinematics as a function to readhipo_helper
- Add Electron smearing to the skimmers for electrons, quasielastic and tagged if MCDATA option is 0
- Smeared electron info is add as another clashit branch in the output. Also corresponding taghit_smeared array is added in case of tagged skimmer.
- Smearing of electrons requires that reconstructed electrons passes PID and DC Fiducial cuts!
- Fixed error in getTaggedInfo from previous version when x' from PRC is calculated. Previous code couldn't be compiled!
- This version compiles but is not tested yet!